### PR TITLE
update smartbit URL, remove dead TBTC explorers

### DIFF
--- a/mbw/src/main/java/com/mycelium/wallet/MbwRegTestEnvironment.java
+++ b/mbw/src/main/java/com/mycelium/wallet/MbwRegTestEnvironment.java
@@ -90,13 +90,11 @@ public class MbwRegTestEnvironment extends MbwEnvironment {
     * The first is the default block explorer if the requested one is not available
     */
    private static final List<BlockExplorer> testnetExplorerClearEndpoints = new ArrayList<BlockExplorer>() {{
-      add(new BlockExplorer("SBT","smartbit", "https://www.sandbox.smartbit.com.au/address/", "https://sandbox.smartbit.com.au/tx/", null, null));
+      add(new BlockExplorer("SBT","smartbit", "https://testnet.smartbit.com.au/address/", "https://testnet.smartbit.com.au/tx/", null, null));
       add(new BlockExplorer("BTL","blockTrail", "https://www.blocktrail.com/tBTC/address/", "https://www.blocktrail.com/tBTC/tx/", null, null));
       add(new BlockExplorer("BPY","BitPay", "https://test-insight.bitpay.com/address/", "https://test-insight.bitpay.com/tx/", null, null));
       add(new BlockExplorer("BEX","blockExplorer", "http://blockexplorer.com/testnet/address/", "https://blockexplorer.com/testnet/tx/", null, null));
       add(new BlockExplorer("BCY","blockCypher", "https://live.blockcypher.com/btc-testnet/address/", "https://live.blockcypher.com/btc-testnet/tx/", null, null));
-      add(new BlockExplorer("BES","bitEasy", "https://www.biteasy.com/testnet/addresses/", "https://www.biteasy.com/testnet/transactions/", null, null));
-      add(new BlockExplorer("CPM","coinprism", "https://testnet.coinprism.info/address/", "https://testnet.coinprism.info/tx/", null, null));
    }};
 
    public List<BlockExplorer> getBlockExplorerList() {

--- a/mbw/src/main/java/com/mycelium/wallet/MbwTestEnvironment.java
+++ b/mbw/src/main/java/com/mycelium/wallet/MbwTestEnvironment.java
@@ -87,13 +87,11 @@ public class MbwTestEnvironment extends MbwEnvironment {
     * The first is the default block explorer if the requested one is not available
     */
    private static final List<BlockExplorer> testnetExplorerClearEndpoints = new ArrayList<BlockExplorer>() {{
-      add(new BlockExplorer("SBT", "smartbit", "https://www.sandbox.smartbit.com.au/address/", "https://sandbox.smartbit.com.au/tx/", null, null));
+      add(new BlockExplorer("SBT", "smartbit", "https://testnet.smartbit.com.au/address/", "https://testnet.smartbit.com.au/tx/", null, null));
       add(new BlockExplorer("BTL", "blockTrail", "https://www.blocktrail.com/tBTC/address/", "https://www.blocktrail.com/tBTC/tx/", null, null));
       add(new BlockExplorer("BPY", "BitPay", "https://test-insight.bitpay.com/address/", "https://test-insight.bitpay.com/tx/", null, null));
       add(new BlockExplorer("BEX", "blockExplorer", "http://blockexplorer.com/testnet/address/", "https://blockexplorer.com/testnet/tx/", null, null));
       add(new BlockExplorer("BCY", "blockCypher", "https://live.blockcypher.com/btc-testnet/address/", "https://live.blockcypher.com/btc-testnet/tx/", null, null));
-      add(new BlockExplorer("BES", "bitEasy", "https://www.biteasy.com/testnet/addresses/", "https://www.biteasy.com/testnet/transactions/", null, null));
-      add(new BlockExplorer("CPM", "coinprism", "https://testnet.coinprism.info/address/", "https://testnet.coinprism.info/tx/", null, null));
    }};
 
    public List<BlockExplorer> getBlockExplorerList() {


### PR DESCRIPTION
I noticed dead links in the testnet wallet - one due to a changed subdomain and the others appear to be services that have gone offline.