### PR TITLE
remove G+ reference from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 Beta channel
 ============
 
-In order to receive updates quicker than others, you need to do two things:
-
-1. Join [the G+ group](https://plus.google.com/communities/102264813364583686576)
-so you are eligible for testing
-2. Then explicitly enable beta versions of the software in
+In order to receive updates quicker than others, you need to enable beta versions of the software in
 [Google Play](https://play.google.com/apps/testing/com.mycelium.wallet)
 
 As beta testers, please make sure you have a recent **backup of the masterseed** and all **private keys** inside Mycelium. Beta testers will experience many bugs.


### PR DESCRIPTION
google+ is no longer available :(

I think Discord may be a good alternative for G+, maybe we could setup a discord server ;) 

source: https://plus.google.com/communities/102264813364583686576

