### PR TITLE
Remove need of GitHub account when cloning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "wallet-android-modularization-tools"]
 	path = wallet-android-modularization-tools
-	url = git@github.com:mycelium-com/wallet-android-modularization-tools
+	url = https://github.com/mycelium-com/wallet-android-modularization-tools
 [submodule "fiosdk_kotlin"]
 	path = fiosdk_kotlin
 	url = https://github.com/mycelium-com/fiosdk_kotlin


### PR DESCRIPTION
git submodule update --init --recursive
only works if a GitHub account is configured with ssh access
fixes #619