### PR TITLE
Fix crash bug by ensuring getTypeByName does not return null

### DIFF
--- a/mbw/src/main/java/com/mycelium/wallet/Utils.java
+++ b/mbw/src/main/java/com/mycelium/wallet/Utils.java
@@ -1159,7 +1159,6 @@ public class Utils {
       return hasPermission;
    }
 
-   @Nullable
    public static AssetInfo getTypeByName(String name) {
       for (CurrencyCode currencyCode : CurrencyCode.values()) {
          if (name.equals(currencyCode.getShortString())) {
@@ -1172,6 +1171,8 @@ public class Utils {
             return coin;
          }
       }
-      return null;
+      // Never set to null. The currentCurrencyMap assumes non-null keys,
+      // which can lead to an exception in CurrencySwitcher.setCurrency
+      return getBtcCoinType();
    }
 }

--- a/mbw/src/main/java/com/mycelium/wallet/Utils.java
+++ b/mbw/src/main/java/com/mycelium/wallet/Utils.java
@@ -1171,8 +1171,13 @@ public class Utils {
             return coin;
          }
       }
+      Logger.getLogger(Utils.class.getSimpleName()).log(Level.SEVERE, "Unknown currency type '" + name + "'");
       // Never set to null. The currentCurrencyMap assumes non-null keys,
       // which can lead to an exception in CurrencySwitcher.setCurrency
-      return getBtcCoinType();
+      CryptoCurrency copyPropsFromType = getBtcCoinType();
+      return new CryptoCurrency("Unknown_" + name, name, "?",
+              copyPropsFromType.getUnitExponent(),
+              copyPropsFromType.getFriendlyDigits(),
+              copyPropsFromType.isUtxosBased());
    }
 }


### PR DESCRIPTION
If an unknown coin type is read from user data, it will cause getTypeByName to return null.  The currentCurrencyMap will then have an asset with key equal to null, which should never happen.  That will later cause a crash in CurrencySwitcher.setCurrency.  This fix here is to use the BTC coin type as the default instead of returning null.